### PR TITLE
🐛 👽 replaced Bitbucket account name with email address

### DIFF
--- a/test-assignments/frontend-react-assignment/README.md
+++ b/test-assignments/frontend-react-assignment/README.md
@@ -8,7 +8,7 @@ Don't stress if you can't get every part done -- spend a maximum of 5 hours on t
 
 The main objective is that the code you submit is well-structured and covered with unit tests.
 
-Submit your code through `BitBucket` by creating a private repository and sharing it with the `recart` user.
+Submit your code through `BitBucket` by creating a private repository and sharing it with the `david.namenyi+bitbucket@recart.com` email address.
 
 ## Tasks
 - Create a new component which does a basic pagination.

--- a/test-assignments/infrastructure-engineer-assignment.md
+++ b/test-assignments/infrastructure-engineer-assignment.md
@@ -27,4 +27,4 @@ We'll discuss your solution in person so you'll get a chance to tell us what els
 
 Feel free to ask questions to clarify the details.
 
-Submit your your code through `bitbucket.org` by creating a **private** repository and sharing it with the `recart` user.
+Submit your your code through `bitbucket.org` by creating a **private** repository and sharing it with the `david.namenyi+bitbucket@recart.com` email address.

--- a/test-assignments/junior-nodejs-assigment.md
+++ b/test-assignments/junior-nodejs-assigment.md
@@ -7,7 +7,7 @@ Your task is to create an API with the endpoints that are documented below. We r
 The goal of the assignment is to get a picture of your programming skills and coding style. Don't stress if you can't get every part done -- spend a maximum of 4-5 hours on this. We'll discuss your solution in person so you'll get a chance to tell us what else you wanted to add and how you planned to implement those.
 
 
-Submit your your code through `bitbucket.org` by creating a **private** repository and sharing it with the `recart` user.
+Submit your your code through `bitbucket.org` by creating a **private** repository and sharing it with the `david.namenyi+bitbucket@recart.com` email address.
 
 Please also provide setup / deploy instructions along with your code, preferrably in the README file. If you write tests, tell us how to run them (e.g.: `npm test`).
 

--- a/test-assignments/senior-backend-assigment.md
+++ b/test-assignments/senior-backend-assigment.md
@@ -12,7 +12,7 @@ Don't stress if you can't get every part done -- spend a maximum of 5 hours on t
 
 Feel free to ask questions to clarify the business need and the details. Also, try to estimate what can be done within the 5 hours time frame and let us know if we need to cut the scope.
 
-Submit your your code through `bitbucket.org` by creating a **private** repository and sharing it with the `recart` user.
+Submit your your code through `bitbucket.org` by creating a **private** repository and sharing it with the `david.namenyi+bitbucket@recart.com` email address.
 
 ---
 


### PR DESCRIPTION
This is needed because Bitbucket made it impossible to share a repository with someone by username. Probably it's a bug on their side.